### PR TITLE
Fix typo in og:description

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
       
 <meta property="og:type"               content="page" />
 <meta property="og:title"              content="Ballerinalang - Flexible. Powerful. Beautiful." />
-<meta property="og:description"        content="Ballerina is a general purpose,oncurrent and strongly typed programming language with both textual and graphical syntaxes, optimized for integration." />
+<meta property="og:description"        content="Ballerina is a general purpose, concurrent and strongly typed programming language with both textual and graphical syntaxes, optimized for integration." />
 <meta property="og:image"              content="https://wso2.cachefly.net/wso2/sites/all/ballerina/img/ballerina-sm.jpg" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:site" content="@ballerinalang">


### PR DESCRIPTION
This is to fix a small typo in one of the open graph meta tags which is very visible (i.e. in slack) when sharing the website link.